### PR TITLE
Update .travis.yml to use main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ before_install:
 before_script:
     - nats/gnatsd &
 
->>>>>>> master
+>>>>>>> main
 script: go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 language: go
 
 services:
@@ -13,20 +12,4 @@ before_install:
 before_script:
     - nats/gnatsd &
 
-=======
-language: go
-
-services:
-    - redis-server
-
-before_install:
-    - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-linux-amd64.zip
-    - unzip gnatsd-v0.9.6-linux-amd64.zip
-    - mv gnatsd-v0.9.6-linux-amd64 nats
-    - chmod +x nats/gnatsd
-
-before_script:
-    - nats/gnatsd &
-
->>>>>>> main
 script: go test -v ./...


### PR DESCRIPTION
This PR updates the .travis.yml file to use the `main` branch instead of `master`. It has been automatically generated and this might not have worked correctly, so please check it carefully.